### PR TITLE
chore: add security tool compliance links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The versions of the standard followed are:
 
 Institutions and associations that should accept this format:
 * Deutsche Kreditwirtschaft
-* FÃ©dÃ©ration bancaire franÃ§aise
+* FÃÂ©dÃÂ©ration bancaire franÃÂ§aise
 
 However, always verify generated files with your bank before using!
 
@@ -46,5 +46,5 @@ Specific version, API stability
 ## Technical debt links
 - [Barometer IT](https://wolterskluwer.barometerit.com/b/system/041800002496)
 - [SonarQube Project](https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml)
-- [Black Duck Project](https://wolterskluwer.app.blackduck.com/api/projects?q=name:php-sepa-xml)
+- [Black Duck Project](https://wolterskluwer.app.blackduck.com/api/projects/3d5da9ec-8af1-4c4d-b949-4d74942760dd)
 - [Checkmarx Project](https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=18816)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The versions of the standard followed are:
 
 Institutions and associations that should accept this format:
 * Deutsche Kreditwirtschaft
-* Fédération bancaire française
+* FÃ©dÃ©ration bancaire franÃ§aise
 
 However, always verify generated files with your bank before using!
 
@@ -47,4 +47,4 @@ Specific version, API stability
 - [Barometer IT](https://wolterskluwer.barometerit.com/b/system/041800002496)
 - [SonarQube Project](https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml)
 - [Black Duck Project](https://wolterskluwer.app.blackduck.com/api/projects?q=name:php-sepa-xml)
-- [Checkmarx Project](https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17859)
+- [Checkmarx Project](https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=18816)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Specific version, API stability
 * [handling Direct Credit](doc/direct_credit.md)
 
 ## Technical debt links
-
-[Barometer IT](https://wolterskluwer.barometerit.com/b/system/041800002496)
-[SonarQube Project](https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml)
+- [Barometer IT](https://wolterskluwer.barometerit.com/b/system/041800002496)
+- [SonarQube Project](https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml)
+- [Black Duck Project](https://wolterskluwer.app.blackduck.com/api/projects?q=name:php-sepa-xml)
+- [Checkmarx Project](https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17859)


### PR DESCRIPTION
## Compliance: Add security tool links

### README
Added "Technical debt links" section with links to: Checkmarx, BlackDuck

Fixes gaps in the [Repo Compliance Report](https://confluence.wolterskluwer.io/pages/viewpage.action?pageId=665556728).