### PR TITLE
chore: add catalog-info.yaml (WK Backstage metadata)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,4 @@
+---
 # Wolters Kluwer Backstage compliant catalog info
 # See https://backstage.io/docs/features/software-catalog/descriptor-format
 apiVersion: backstage.io/v1alpha1
@@ -6,18 +7,21 @@ metadata:
   name: php-sepa-xml
   description: "SEPA file generator in PHP"
   annotations:
-    wolterskluwer.io/bit-id: "041800002496"
+    wolterskluwer.io/bit-id: '041800002496'
 spec:
   type: library
   lifecycle: production
   owner: Glenn.Van-Den-Broeck@wolterskluwer.com
 links:
-  - url: https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml
+  - url: "https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%\
+    3Aphp-sepa-xml"
     type: SAST
     title: SonarQube
-  - url: https://wolterskluwer.app.blackduck.com/api/projects/3d5da9ec-8af1-4c4d-b949-4d74942760dd
+  - url: "https://wolterskluwer.app.blackduck.com/api/projects/3d5da9ec-8af1-4c\
+    4d-b949-4d74942760dd"
     type: SCA
     title: Black Duck
-  - url: https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17859
+  - url: "https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx\
+    ?projectid=17859"
     type: SAST
     title: Checkmarx

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,23 @@
+# Wolters Kluwer Backstage compliant catalog info
+# See https://backstage.io/docs/features/software-catalog/descriptor-format
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: php-sepa-xml
+  description: "SEPA file generator in PHP"
+  annotations:
+    wolterskluwer.io/bit-id: "041800002496"
+spec:
+  type: library
+  lifecycle: production
+  owner: Glenn.Van-Den-Broeck@wolterskluwer.com
+links:
+  - url: https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Aphp-sepa-xml
+    type: SAST
+    title: SonarQube
+  - url: https://wolterskluwer.app.blackduck.com/api/projects/3d5da9ec-8af1-4c4d-b949-4d74942760dd
+    type: SCA
+    title: Black Duck
+  - url: https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17859
+    type: SAST
+    title: Checkmarx


### PR DESCRIPTION
Adds `catalog-info.yaml` at the repo root per the WK Metadata Marker File spec (Backstage-compatible).

- `metadata.name`: repo name
- `metadata.annotations.wolterskluwer.io/bit-id`: extracted from the README `Barometer IT` link (falls back to `041800002496` when not present in README)
- `spec.type`: inferred from repo purpose (service / library / infrastructure / pipeline / documentation / desktop / test-automation)
- `spec.lifecycle`: `production` for customer-facing repos, `support` for repos flagged `[x] non-production code only` in the README or with only SDLC/tooling scope (also `cf-operations`)
- `spec.owner`: `Glenn.Van-Den-Broeck@wolterskluwer.com`
- `links[]`: extracted from the README `## Technical debt links` section (SonarQube = SAST, Black Duck = SCA, Checkmarx = SAST); omitted when the README flags the repo as non-production or SCA-not-applicable

Spec reference: https://confluence.wolterskluwer.io/spaces/DAACCE/pages/934545428/